### PR TITLE
Ability to set a default keyboard on startup

### DIFF
--- a/taranLUAmacros.lua
+++ b/taranLUAmacros.lua
@@ -1,9 +1,24 @@
 -- get luamacros here: http://www.hidmacros.eu/
 -- plug in your 2nd keyboard, load this script into LUAmacros, and press the triangle PLAY button.
--- Then, press any key on that keyboard to assign logical name ('MACROS') to macro keyboard
--- When done this way, you have to reassign the name to your 2nd keyboard every time you open LUAmacros, using the play button located above.
--- There may be a better, more permanent solution, but I don't know it.
-lmc_assign_keyboard('MACROS');
+
+local config_file = "config.txt"
+
+-- Attempt to map the keyboard config file if it exists
+local config = io.open(config_file, "r")
+if(config ~= nil) then
+  local device_string = config:read()
+  if(device_string ~= nil and device_string ~= '') then
+    lmc_device_set_name('MACROS', device_string)
+  end
+  config:close()
+end
+
+lmc_assign_keyboard('MACROS')
+
+if(config == nil) then
+  print("To assign this keyboard automatically, copy a unique portion of the string from the line labelled MACROS (such as the VID_XXXX or PID_XXXX value) and save it to "..config_file..":")
+  lmc_print_devices()
+end 
 
 sendToAHK = function (key)
       print('It was assigned string:    ' .. key)


### PR DESCRIPTION
Rather than manually pressing a key each time you start the script to identify the keyboard, this will attempt to look for a config.txt file, containing a substring belonging to the macro keyboard device instance path.

If the config file contains a value, it will automatically set the keyboard to the one which contains the substring. If no config file is found, it will prompt you to press a key on the macros keyboard, and then print out all detected keyboards. 

```
<unassigned>  :  \\?\HID#VID_045E&PID_0745&MI_00#7&8C8C8AF&0&0000#{884B96C3-56EF-11D1-BC8C-00A0C91405DD} [65599] :  keyboard
MACROS  :  \\?\HID#VID_24F0&PID_0140&MI_00#8&4784382&0&0000#{884B96C3-56EF-11D1-BC8C-00A0C91405DD} [65597] :  keyboard
Total number of devices: 2
```

On the line labelled MACROS, you can copy a portion of the device instance string into a new config.txt file to remember that device.  I'm using the vendor ID (`VID_24F0`) as my keyboards are two different brands, however you can use any part of the device instance path. 