### PR TITLE
Remove unnecessary IF function

### DIFF
--- a/LUAMACROS/SECOND KEYBOARD script for LUA MACROS.lua
+++ b/LUAMACROS/SECOND KEYBOARD script for LUA MACROS.lua
@@ -4,24 +4,22 @@
 clear() --clear the console from last run
 local keyboardIdentifier = '0000AAA'
 
-
-
 --You need to get the identifier code for the keyboard with name "MACROS"
 --This appears about halfway through the SystemID item and looks like 1BB382AF or some other alphanumeric combo. 
--- It's usually 7 or 8 characters long.
---Once you have this identifier, replace the value of keyboardIdentifier with it
+--It's usually 7 or 8 characters long.
+--Once you have this identifier, replace the value of keyboardIdentifier (above) with it
 
---Don't ask for keyboard assignment help if the user has manually entered a keyboard identifier
-if keyboardIdentifier == '0000AAA' then
-	lmc_assign_keyboard('MACROS');
-else lmc_device_set_name('MACROS', keyboardIdentifier);
-end
+lmc_device_set_name('MACROS', keyboardIdentifier);
+--The lmc_assign_keyboard command will only run if the keyboard is not already assigned to a device.
+lmc_assign_keyboard('MACROS');
+
 --This lists connected keyboards
 dev = lmc_get_devices()
 for key,value in pairs(dev) do
   print(key..':')
   for key2,value2 in pairs(value) do print('  '..key2..' = '..value2) end
 end   
+
 print('You need to get the identifier code for the keyboard with name "MACROS"')
 print('Then replace the first 0000AAA value in the code with it. This will prevent having to manually identify keyboard every time.')
 -- Hide window to tray to keep taskbar tidy  


### PR DESCRIPTION
The IF function that was previously here is unnecessary because LUA already checks whether a device is already matching the specified name when `lmc_assign_keyboard('name');` is run. If the device is assigned then it will not ask for manual assignment.