### PR TITLE
Trigger the autohotkey script using lmc_spawn, freeing up the F24 key

### DIFF
--- a/LUAMACROS/2nd_keyboard_if_using_luamacros.ahk
+++ b/LUAMACROS/2nd_keyboard_if_using_luamacros.ahk
@@ -35,7 +35,7 @@ Menu, Tray, Icon, shell32.dll, 283 ; this changes the tray icon to a little keyb
 
 #IfWinActive ;---- This will allow for everything below this line to work in ANY application.
 
-~F24::
+; ~F24:: we don't need this, because the script is now activated via the command line. in the future it *could* be possible to eliminate the need for the keypress file, using command line arguments. 
 FileRead, key, C:\AHK\2nd-keyboard\support_files\keypressed.txt
 tippy(key) ;<--- this function will just launch a quick tooltip that shows you what key you pressed. OPTIONAL.
 If (key = "o")

--- a/LUAMACROS/README.md
+++ b/LUAMACROS/README.md
@@ -13,7 +13,7 @@ A quickstart guide for using a second keyboard purely for macros on Windows.
 1. Ensure that both your keyboards are plugged in.
 2. Download and install [LuaMacros](http://www.hidmacros.eu/forum/viewtopic.php?f=10&t=241#p794) and [AuthoHotkey](https://autohotkey.com/).
 3. Download `2nd_keyboard_if_using_luamacros.ahk`,  `SECOND_KEYBOARD_script_for_LUA_MACROS.lua`, and `keypressed.txt` from this github repository, by clicking on the RAW button for each, and then selecting FILE > SAVE AS. Save them all into the same folder. I STRONGLY recommend that you use `C:\AHK\2nd-keyboard\LUAMACROS`. That way, you won't have to change any file paths at all! The only downside is that ALL users will have access to those scripts.
-4. Open `SECOND_KEYBOARD_script_for_LUA_MACROS.lua` using LuaMacros.exe, which will allow you to view and modify the code. You'll need to change the file path of keypressed.txt at least.
+4. Open `SECOND_KEYBOARD_script_for_LUA_MACROS.lua` using LuaMacros.exe, which will allow you to view and modify the code. You'll need to change the file path of keypressed.txt at least. On line 43, you'll need to change the path to wherever you're saving the autohotkey script to. You might also need to add autohotkey.exe to your PATH environment variable. 
 5. Click on the "play" arrow button. An identification window should pop up. Press any key on your 2nd keyboard, and luamacros will identify that device as your 2nd keyboard.
 6. Typing on your 2nd keyboard should no longer work, since LuaMacros is now intercepting and blocking those keystrokes.
 7. Press the spacebar on your second keyboard, then check keypressed.txt to see if it now contains the string "spacebar". If so, you got it working!

--- a/LUAMACROS/SECOND_KEYBOARD_script_for_LUA_MACROS.lua
+++ b/LUAMACROS/SECOND_KEYBOARD_script_for_LUA_MACROS.lua
@@ -40,7 +40,8 @@ sendToAHK = function (key)
       file:write(key)
       file:flush() --"flush" means "save." Lol.
       file:close()
-      lmc_send_keys('{F24}')  -- This presses F24. Using the F24 key to trigger AutoHotKey is probably NOT the best method. Feel free to program something better!
+	lmc_spawn('AutoHotkey.exe','C:\\LOCATION\\TO\\AHK\\SCRIPT.ahk') --change this to wherever your ahk script is, you might need to add AutoHotkey.exe to your path
+--       lmc_send_keys('{F24}')  -- Disable this, as we can trigger the ahk script using lmc_spawn, above
 end
 
 local config = {


### PR DESCRIPTION
Since you can run ahk scripts over command line, `lmc_spawn()` can be used, I just removed the line that presses F24 in luamacros, and the one that listens for it in ahk. No further modification, and now the F24 key can be used for a macro or something.